### PR TITLE
Dockerize backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:16
+
+WORKDIR /code
+COPY package.json ./
+
+RUN npm install
+COPY . /code
+
+CMD ["node", "."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,5 @@ WORKDIR /code
 COPY package.json ./
 
 RUN npm install
+RUN npm install -g nodemon
 COPY . /code
-
-CMD ["node", "."]

--- a/README.md
+++ b/README.md
@@ -9,15 +9,12 @@ API routes saved in ./routes
 Mongoose Schema saved in ./model
 Database connection made in ./data/db.js
 
-## Testing
+## Ingesting SIS Courses into the Local DB
 
-1. You must have a local mongodb server running, search up how to install it for your OS.
-2. You can ensure you have it installed with `mongod --version`
-3. If you try to run mongod, you will get an error saying there's no directory called
-   `data/db`. Since that is an existing file in this project, I suggest creating a
-   directory in the base directory called `testdb/`. I've added this to the .gitignore
-   so you don't have to worry about committing it.
-4. The command to run mongodb then becomes: `mongod --dbpath ./testdb`. You have to use
-   `sudo`. You must keep the terminal you run this in active to keep the db connection
-   alive.
-5. You can now run the tests with `npm test` in a separate terminal.
+1. Attach a shell to the web docker container.
+2. Navigate to `/code/data`.
+3. Run `node cacheSISCoursesWithVersions.js`
+
+You can see the contents of your local database in MongoDBCompass. 
+
+The URL is `mongodb://localhost:27017/debug`.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # uCredit-API
 
 To run program:
-Step 1)npm i  
-Step 2)node .
-If run locally the default port is 4567.
+
+```
+docker-compose build && docker-compose up
+```
+
+If run locally, the default port is 4567 and Mongodb port is 27017.
 
 API routes saved in ./routes
 Mongoose Schema saved in ./model

--- a/data/db.js
+++ b/data/db.js
@@ -4,7 +4,8 @@ const mongoose = require("mongoose");
 //set up db connection link
 const password = process.env.DB_ADMIN_PASSWORD;
 const dbname = "ucredit-db";
-const URI = `mongodb+srv://ucredit-admin:${password}@cluster0.ccsle.mongodb.net/${dbname}?retryWrites=true&w=majority`;
+const debug = process.env.DEBUG === "True";
+const URI = debug ? "mongodb://db:27017/debug" : `mongodb+srv://ucredit-admin:${password}@cluster0.ccsle.mongodb.net/${dbname}?retryWrites=true&w=majority`;
 //config connect options
 const option = {
   useNewUrlParser: true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services: 
+    db:
+      image: mongo:5.0.6
+      ports:
+        - "27017:27017"
+      volumes:
+        - db:/testdb
+    web:
+      depends_on:
+        - db
+      build: .
+      ports:
+        - "4567:4567"
+volumes:
+  db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,15 @@ services:
       image: mongo:5.0.6
       ports:
         - "27017:27017"
-      volumes:
-        - db:/testdb
     web:
-      depends_on:
-        - db
+      environment:
+        - DEBUG=True
       build: .
+      volumes:
+        - .:/code
       ports:
         - "4567:4567"
+      depends_on:
+        - db
 volumes:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,14 @@ services:
       image: mongo:5.0.6
       ports:
         - "27017:27017"
+      # Uncomment if you want db logs; most devs will probably find these annoying
+      logging:
+        driver: "none"
     web:
       environment:
         - DEBUG=True
       build: .
+      command: nodemon .
       volumes:
         - .:/code
       ports:

--- a/model/User.js
+++ b/model/User.js
@@ -8,7 +8,7 @@ const userSchema = new Schema({
   affiliation: { type: String }, //STUDENT, FACULTY or STAFF
   school: { type: String },
   grade: { type: String }, //AE UG Sophomore
-  plan_ids: [{ type: Schema.Types.ObjectId, ref: "Plan" }],
+  plan_ids: [{ type: Schema.Types.ObjectId, ref: "Plan", default: [] }],
   whitelisted_plan_ids: [
     { type: Schema.Types.ObjectId, ref: "Plan", default: [] },
   ],

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@shelf/jest-mongodb": "^2.2.0",
     "@types/jest": "^27.4.0",
+    "jest": "^27.5.1",
     "supertest": "^6.1.6"
   }
 }

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -9,9 +9,6 @@ function returnData(data, res) {
 
 //set status code of the response and send error info to the user in json
 function errorHandler(res, status, err) {
-  // console.log("TESTESTTEST");
-  // console.log(res);
-
   res.status(status).json({
     errors: [
       {

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -9,6 +9,9 @@ function returnData(data, res) {
 
 //set status code of the response and send error info to the user in json
 function errorHandler(res, status, err) {
+  // console.log("TESTESTTEST");
+  // console.log(res);
+
   res.status(status).json({
     errors: [
       {

--- a/routes/majors.spec.ts
+++ b/routes/majors.spec.ts
@@ -1,70 +1,70 @@
-const mongoose = require("mongoose");
-const supertest = require("supertest");
-const { returnData } = require("./helperMethods");
-const majors = require("../model/Major");
-const createApp = require("../app");
+// const mongoose = require("mongoose");
+// const supertest = require("supertest");
+// const { returnData } = require("./helperMethods");
+// const majors = require("../model/Major");
+// const createApp = require("../app");
 
-beforeEach((done) => {
-  mongoose
-    .connect("mongodb://localhost:27017/majors", { useNewUrlParser: true })
-    .then(() => done());
-});
+// beforeEach((done) => {
+//   mongoose
+//     .connect("mongodb://localhost:27017/majors", { useNewUrlParser: true })
+//     .then(() => done());
+// });
 
-afterEach((done) => {
-  mongoose.connection.db.dropDatabase(() => {
-    mongoose.connection.close(() => done());
-  });
-});
+// afterEach((done) => {
+//   mongoose.connection.db.dropDatabase(() => {
+//     mongoose.connection.close(() => done());
+//   });
+// });
 
-const request = supertest(createApp());
+// const request = supertest(createApp());
 
-describe("major routes", () => {
-  it("should create a new major", async () => {
-    await request
-      .post("/api/majors")
-      .send(majorData)
-      .then(async () => {
-        const major = await majors.findOne({ department: "Computer Science" });
-        expect(major).toBeTruthy();
-      });
-  });
+// describe("major routes", () => {
+//   it("should create a new major", async () => {
+//     await request
+//       .post("/api/majors")
+//       .send(majorData)
+//       .then(async () => {
+//         const major = await majors.findOne({ department: "Computer Science" });
+//         expect(major).toBeTruthy();
+//       });
+//   });
 
-  it("should return a major after posting", async () => {
-    await request
-      .post("/api/majors")
-      .send(majorData)
-      .then(async (res) => {
-        const data = res.body.data;
-        expect(data).toMatchObject(majorData);
-      });
-  });
-});
+//   it("should return a major after posting", async () => {
+//     await request
+//       .post("/api/majors")
+//       .send(majorData)
+//       .then(async (res) => {
+//         const data = res.body.data;
+//         expect(data).toMatchObject(majorData);
+//       });
+//   });
+// });
 
-const data = { test: true };
-const majorData = {
-  degree_name: "B.A. Computer Science",
-  department: "Computer Science",
-  total_degree_credit: 120,
-  wi_credit: 12,
-  distributions: [
-    {
-      name: "Core",
-      required_credits: 15,
-      min_cedits_per_course: 3,
-      description: "Core courses",
-      criteria: "Criteria",
-      user_select: false, //if true, user can put any course into this distribution
-      double_count: true, //courses being classified to this distribution might also be double counted for another distribution
-      exception: "exception?", //course that match the exception expression cannot be added toward this distirbution
-      fine_requirements: [
-        {
-          description: "Data Structures",
-          required_credits: 4,
-          criteria: "Fine requirement criteria",
-          exception: "Fine exception?",
-          exclusive: false,
-        },
-      ],
-    },
-  ],
-};
+// const data = { test: true };
+// const majorData = {
+//   degree_name: "B.A. Computer Science",
+//   department: "Computer Science",
+//   total_degree_credit: 120,
+//   wi_credit: 12,
+//   distributions: [
+//     {
+//       name: "Core",
+//       required_credits: 15,
+//       min_cedits_per_course: 3,
+//       description: "Core courses",
+//       criteria: "Criteria",
+//       user_select: false, //if true, user can put any course into this distribution
+//       double_count: true, //courses being classified to this distribution might also be double counted for another distribution
+//       exception: "exception?", //course that match the exception expression cannot be added toward this distirbution
+//       fine_requirements: [
+//         {
+//           description: "Data Structures",
+//           required_credits: 4,
+//           criteria: "Fine requirement criteria",
+//           exception: "Fine exception?",
+//           exclusive: false,
+//         },
+//       ],
+//     },
+//   ],
+// };

--- a/routes/planReview.js
+++ b/routes/planReview.js
@@ -9,7 +9,7 @@ router.post("/api/planReview/addReviewer", (req, res) => {
   const plan_id = req.body.plan_id;
   const reviewer_id = req.body.reviewer_id;
   if (!plan_id || !reviewer_id) {
-    errorHandler(res, 405, {
+    errorHandler(res, 401, {
       message: "Missing plan_id or reviewer_id in the request body.",
     });
   }
@@ -26,10 +26,10 @@ router.post("/api/planReview/addReviewer", (req, res) => {
             user.whitelisted_plan_ids.push(plan_id);
             user.save();
           })
-          .catch((err) => errorHandler);
+          .catch((err) => errorHandler(res, 400, err));
         plan.save();
       } else {
-        errorHandler(res, 400, {
+        errorHandler(res, 402, {
           message: "Reviewer already added for this plan.",
         });
       }
@@ -56,16 +56,16 @@ router.delete("/api/planReview/removeReviewer", (req, res) => {
             user.whitelisted_plan_ids.splice(plan_index, 1);
             user.save();
           })
-          .catch((err) => errorHandler(err));
+          .catch((err) => errorHandler(res, 400, err));
         plan.save();
       } else {
-        errorHandler(res, 404, {
+        errorHandler(res, 402, {
           message: "Reviewer does not exist for this plan.",
         });
       }
       returnData(plan, res);
     })
-    .catch((err) => errorHandler(err));
+    .catch((err) => errorHandler(res, 400, err));
 });
 
 module.exports = router;

--- a/routes/planReview.js
+++ b/routes/planReview.js
@@ -35,7 +35,7 @@ router.post("/api/planReview/addReviewer", (req, res) => {
       }
       returnData(plan, res);
     })
-    .catch((err) => errorHandler(err));
+    .catch((err) => errorHandler(res, 400, err));
 });
 
 router.delete("/api/planReview/removeReviewer", (req, res) => {

--- a/routes/planReview.js
+++ b/routes/planReview.js
@@ -9,7 +9,7 @@ router.post("/api/planReview/addReviewer", (req, res) => {
   const plan_id = req.body.plan_id;
   const reviewer_id = req.body.reviewer_id;
   if (!plan_id || !reviewer_id) {
-    errorHandler(res, 400, {
+    errorHandler(res, 405, {
       message: "Missing plan_id or reviewer_id in the request body.",
     });
   }

--- a/routes/sso.js
+++ b/routes/sso.js
@@ -15,6 +15,7 @@ const router = express.Router();
 const secret = process.env.SESSION_SECRET;
 const PbK = process.env.PUBLIC_KEY;
 const PvK = process.env.PRIVATE_KEY;
+const DEBUG = process.env.DEBUG === "True";
 
 const JHU_SSO_URL = "https://idp.jh.edu/idp/profile/SAML2/Redirect/SSO";
 const SP_NAME = "https://ucredit-api.herokuapp.com";
@@ -133,13 +134,30 @@ router.get("/api/verifyLogin/:hash", (req, res) => {
   });
 });
 
-router.get("/api/backdoor/verification/:id", (req, res) => {
-  const id = req.params.id;
-  users
-    .findById(id)
-    .then((retrievedUser) => returnData(retrievedUser, res))
-    .catch((err) => errorHandler(res, 500, res));
-});
+if (DEBUG) {
+  router.get("/api/backdoor/verification/:id", (req, res) => {
+    const id = req.params.id;
+    users
+      .findById(id)
+      .then(async (user) => {
+        if (user) {
+          returnData(user, res);
+        } else {
+          user = {
+            _id: id,
+            name: id,
+            email: `${id}@fakeemail.com`,
+            affiliation: "STAFF",
+            grade: "AE UG Freshman",
+            school: "jooby hooby",
+          };
+          user = await users.create(user);
+          console.log(user);
+          returnData(user, res);
+        }
+      })
+  });
+}
 
 router.delete("/api/verifyLogin/:hash", (req, res) => {
   const hash = req.params.hash;

--- a/tests/routes/reviewer.test.js
+++ b/tests/routes/reviewer.test.js
@@ -14,19 +14,15 @@ beforeEach(async () => {
 describe(`Test endpoint ${endpoint}`, () => {
   describe("HTTP POST request", () => {
     test("Return 401 if missing plan_id or reviewer_id in request body", async () => {
-        const response1 = await request.post(`${endpoint}`).send({
-            plan_id: "asdfjksla"
-        });
-        const response2 = await request.post(`${endpoint}`).send({
-            reviewer_id: "asdfjkl"
-        });
-        expect(response1.status).toBe(401);
-        expect(response2.status).toBe(401);
+      const response1 = await request.post(`${endpoint}`).send({
+        plan_id: "asdfjksla",
+      });
+      const response2 = await request.post(`${endpoint}`).send({
+        reviewer_id: "asdfjkl",
+      });
+      expect(response1.status).toBe(401);
+      expect(response2.status).toBe(401);
     });
-
-    // test("Return 402 if reviewer already added on plan", async () => {
-
-    // });
 
     test("Return 200 if successfully added reviewer", async () => {
       const response = await request.post(`${endpoint}`).send({
@@ -35,7 +31,6 @@ describe(`Test endpoint ${endpoint}`, () => {
       });
       expect(response.status).toBe(200);
     });
-
   });
 });
 

--- a/tests/routes/reviewer.test.js
+++ b/tests/routes/reviewer.test.js
@@ -13,31 +13,29 @@ beforeEach(async () => {
 
 describe(`Test endpoint ${endpoint}`, () => {
   describe("HTTP POST request", () => {
-    // test("Return 400 if missing plan_id or reviewer_id in request body", async () => {
-    //     const response1 = await request.post(`${endpoint}`).send({
-    //         plan_id: "asdfjksla"
-    //     });
-    //     const response2 = await request.post(`${endpoint}`).send({
-    //         reviewer_id: "asdfjkl"
-    //     });
-    //     expect(response1.status).toBe(400);
-    //     expect(response2.status).toBe(400);
+    test("Return 401 if missing plan_id or reviewer_id in request body", async () => {
+        const response1 = await request.post(`${endpoint}`).send({
+            plan_id: "asdfjksla"
+        });
+        const response2 = await request.post(`${endpoint}`).send({
+            reviewer_id: "asdfjkl"
+        });
+        expect(response1.status).toBe(401);
+        expect(response2.status).toBe(401);
+    });
+
+    // test("Return 402 if reviewer already added on plan", async () => {
+
     // });
 
-    test("Return 200 on success", async () => {
+    test("Return 200 if successfully added reviewer", async () => {
       const response = await request.post(`${endpoint}`).send({
         plan_id: "asdfjksla",
         reviewer_id: "asdfjkl",
       });
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(200);
     });
-    // test("Return 400 if reviewer already added on plan", async () => {
 
-    // });
-
-    // test("Return 200 if successfully added reviewer", async() => {
-
-    // });
   });
 });
 

--- a/tests/routes/reviewer.test.js
+++ b/tests/routes/reviewer.test.js
@@ -1,13 +1,17 @@
 // Run test suite with: npm run test tests/routes/reviewer.test.js
 
+const mongoose = require("mongoose");
 const supertest = require("supertest");
 const createApp = require("../../app");
 
 const request = supertest(createApp());
 const endpoint = "/api/planReview/addReviewer";
 
-describe(`Test endpoint ${endpoint}`, () => {
+beforeEach(async () => {
+  await mongoose.connect(global.__MONGO_URI__);
+});
 
+describe(`Test endpoint ${endpoint}`, () => {
   describe("HTTP POST request", () => {
     // test("Return 400 if missing plan_id or reviewer_id in request body", async () => {
     //     const response1 = await request.post(`${endpoint}`).send({
@@ -21,19 +25,22 @@ describe(`Test endpoint ${endpoint}`, () => {
     // });
 
     test("Return 200 on success", async () => {
-        const response = await request.post(`${endpoint}`).send({
-            plan: "asdfjksla",
-            reviewer: "asdfjkl"
-        });
-        expect(response.status).toBe(200);
+      const response = await request.post(`${endpoint}`).send({
+        plan_id: "asdfjksla",
+        reviewer_id: "asdfjkl",
+      });
+      expect(response.status).toBe(400);
     });
     // test("Return 400 if reviewer already added on plan", async () => {
-      
+
     // });
 
     // test("Return 200 if successfully added reviewer", async() => {
 
     // });
   });
+});
 
+afterEach(async () => {
+  await mongoose.disconnect();
 });

--- a/tests/routes/reviewer.test.js
+++ b/tests/routes/reviewer.test.js
@@ -1,0 +1,38 @@
+// Run test suite with: npm run test tests/routes/reviewer.test.js
+
+const mongoose = require("mongoose");
+const supertest = require("supertest");
+const createApp = require("../../app");
+
+const request = supertest(createApp());
+const endpoint = "/api/planReview/addReviewer";
+
+describe(`Test endpoint ${endpoint}`, () => {
+
+  describe("HTTP POST request", () => {
+    test("Return 400 if missing plan_id or reviewer_id in request body", async () => {
+      // console.log(await request.post(`${endpoint}`).send({
+      //   plan_id: "asdfjakl"
+      // }).expect(400));
+      console.log(await request.post(`${endpoint}`).send({plan_id: "asdfjakl"}).body);
+      // console.log(await request.post(`${endpoint}`);
+        // const response = await request.post(`${endpoint}`).send({
+        //     plan_id: "asdfjksla"
+        // })
+        // .then(async (res) => {
+        //   expect(res.status).toBe(400);
+        // });
+        // console.log(response);
+        // expect(response.status).toBe(400);
+    });
+
+    test("Return 400 if reviewer already added on plan", async () => {
+      
+    });
+
+    test("Return 200 if successfully added reviewer", async() => {
+
+    });
+  });
+
+});

--- a/tests/routes/reviewer.test.js
+++ b/tests/routes/reviewer.test.js
@@ -1,6 +1,5 @@
 // Run test suite with: npm run test tests/routes/reviewer.test.js
 
-const mongoose = require("mongoose");
 const supertest = require("supertest");
 const createApp = require("../../app");
 
@@ -10,29 +9,31 @@ const endpoint = "/api/planReview/addReviewer";
 describe(`Test endpoint ${endpoint}`, () => {
 
   describe("HTTP POST request", () => {
-    test("Return 400 if missing plan_id or reviewer_id in request body", async () => {
-      // console.log(await request.post(`${endpoint}`).send({
-      //   plan_id: "asdfjakl"
-      // }).expect(400));
-      console.log(await request.post(`${endpoint}`).send({plan_id: "asdfjakl"}).body);
-      // console.log(await request.post(`${endpoint}`);
-        // const response = await request.post(`${endpoint}`).send({
-        //     plan_id: "asdfjksla"
-        // })
-        // .then(async (res) => {
-        //   expect(res.status).toBe(400);
-        // });
-        // console.log(response);
-        // expect(response.status).toBe(400);
-    });
+    // test("Return 400 if missing plan_id or reviewer_id in request body", async () => {
+    //     const response1 = await request.post(`${endpoint}`).send({
+    //         plan_id: "asdfjksla"
+    //     });
+    //     const response2 = await request.post(`${endpoint}`).send({
+    //         reviewer_id: "asdfjkl"
+    //     });
+    //     expect(response1.status).toBe(400);
+    //     expect(response2.status).toBe(400);
+    // });
 
-    test("Return 400 if reviewer already added on plan", async () => {
+    test("Return 200 on success", async () => {
+        const response = await request.post(`${endpoint}`).send({
+            plan: "asdfjksla",
+            reviewer: "asdfjkl"
+        });
+        expect(response.status).toBe(200);
+    });
+    // test("Return 400 if reviewer already added on plan", async () => {
       
-    });
+    // });
 
-    test("Return 200 if successfully added reviewer", async() => {
+    // test("Return 200 if successfully added reviewer", async() => {
 
-    });
+    // });
   });
 
 });


### PR DESCRIPTION
Dockerizes the backend: 
This makes it so that you can run a local database and server with just one command: `docker-compose up`.
You should no longer need to access the production database; however, this means you must ingest SIS course data yourself. Instructions are found in the README file.

This was branched off of @DenouementX's branch iter1-lawrence, so that's why you see some changes I didn't make. 

As a follow up, we should definitely remove `localhost` from your CORS headers on the server, as well as our own API. I've also heard that there's no user authentication in the backend routes...
