### PR TITLE
Error handling

### DIFF
--- a/model/Comment.js
+++ b/model/Comment.js
@@ -13,7 +13,7 @@ const commentSchema = new Schema({
   },
   thread_id: { type: Schema.Types.ObjectId, ref: "Thread", required: true },
   message: { type: String, required: true },
-  date: { type: Date },
+  date: { type: Date, required: true },
 });
 
 const Comment = mongoose.model("Comment", commentSchema);

--- a/routes/course.js
+++ b/routes/course.js
@@ -71,11 +71,10 @@ router.post("/api/courses", async (req, res) => {
     .findById(course.plan_id)
     .then((plan) => {
       course.distribution_ids.forEach((id) => {
-        if (!plan.distribution_ids.includes(id)) {
+        if (!plan.distribution_ids.includes(id)) 
           errorHandler(res, 400, {
             message: "Invalid combination of plan_id and distribution_ids.",
           });
-        }
       });
     })
     .catch((err) => {

--- a/routes/course.js
+++ b/routes/course.js
@@ -67,11 +67,9 @@ router.get("/api/coursesByTerm/:plan_id", (req, res) => {
 //distribution field is also updated
 router.post("/api/courses", async (req, res) => {
   const course = req.body;
-  //console.log("course is ", course);
   await plans
     .findById(course.plan_id)
     .then((plan) => {
-      //console.log(plan);
       course.distribution_ids.forEach((id) => {
         if (!plan.distribution_ids.includes(id)) {
           errorHandler(res, 400, {
@@ -81,7 +79,6 @@ router.post("/api/courses", async (req, res) => {
       });
     })
     .catch((err) => {
-      //console.log("here", err);
       errorHandler(res, 500, err);
     });
   courses
@@ -98,7 +95,6 @@ router.post("/api/courses", async (req, res) => {
             distributionCreditUpdate(distribution, retrievedCourse, true)
           )
           .catch((err) => {
-            console.log("or here", err);
             errorHandler(res, 500, err);
           });
       });
@@ -140,7 +136,6 @@ router.patch("/api/courses/changeStatus/:course_id", (req, res) => {
         returnData(course, res);
       })
       .catch((err) => {
-        console.log("here is error\n" + err);
         errorHandler(res, 404, err);
       });
   }
@@ -171,7 +166,6 @@ router.patch("/api/courses/dragged", (req, res) => {
         { $pull: { courses: c_id } },
         { new: true, runValidators: true }
       )
-      .then(() => console.log("course_id deleted from old year."))
       .catch((err) => errorHandler(res, 500, err));
 
     years
@@ -181,7 +175,6 @@ router.patch("/api/courses/dragged", (req, res) => {
         { new: true, runValidators: true }
       )
       .then((y) => {
-        console.log("course_id added to new year.");
         courses
           .findByIdAndUpdate(
             c_id,

--- a/routes/course.js
+++ b/routes/course.js
@@ -82,21 +82,17 @@ router.post("/api/courses", async (req, res) => {
     });
   courses
     .create(course)
-    .then((retrievedCourse) => {
-      retrievedCourse.distribution_ids.forEach((id) => {
-        distributions
+    .then(async (retrievedCourse) => {
+      for (let id of retrievedCourse.distribution_ids) {
+        const distribution = await distributions
           .findByIdAndUpdate(
             id,
             { $push: { courses: retrievedCourse._id } },
             { new: true, runValidators: true }
           )
-          .then((distribution) =>
-            distributionCreditUpdate(distribution, retrievedCourse, true)
-          )
-          .catch((err) => {
-            errorHandler(res, 500, err);
-          });
-      });
+        await distributionCreditUpdate(distribution, retrievedCourse, true);
+      }
+      
       //add course id to user plan's year array
       let query = {};
       query[retrievedCourse.year] = retrievedCourse._id; //e.g. { freshman: id }

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -10,6 +10,7 @@ function returnData(data, res) {
 
 //set status code of the response and send error info to the user in json
 function errorHandler(res, status, err) {
+  if (res.statusCode !== 200) return; 
   res.status(status).json({
     errors: [
       {

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -22,6 +22,7 @@ function errorHandler(res, status, err) {
 }
 
 async function distributionCreditUpdate(distribution, course, add) {
+  if (!distribution) return; 
   if (add) {
     distribution.planned += course.credits;
     if (course.taken) {

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -10,7 +10,7 @@ function returnData(data, res) {
 
 //set status code of the response and send error info to the user in json
 function errorHandler(res, status, err) {
-  if (res.statusCode !== 200) return; 
+  if (res.headersSent) return; 
   res.status(status).json({
     errors: [
       {


### PR DESCRIPTION
A bad request error in the add course route caused the server to crash, revealing that backend is not handling errors properly. The backend produced multiple responses per HTTP request, resulting in the [`ERR_HTTP_HEADERS_SENT`](https://stackoverflow.com/questions/52122272/err-http-headers-sent-cannot-set-headers-after-they-are-sent-to-the-client) error which crashed the server. 

Cause: 
- nested catch blocks
- synchronous error throws on operations that should be awaited
- calling returnData or errorHandler multiple times, attempting to 'reset the headers after they are sent' 

Fix: 
- add `if (res.headersSent) return;` in `errorHandler` to check if a response was already sent to current request 
- await asynchronous operations to handle errors 