### PR TITLE
Roadmap plan create route

### DIFF
--- a/model/RoadmapPlan.js
+++ b/model/RoadmapPlan.js
@@ -11,7 +11,7 @@ const roadmapPlanSchema = new Schema({
   name: { type: String, required: true },
   description: { type: String },
   majors: { type: [String] },
-  tags: { type: [String] },
+  tags: { type: [String], default: [] },
   num_likes: { type: Number, default: 0 },
   year_ids: [{ type: Schema.Types.ObjectId, ref: "Year" }],
   distribution_ids: [{ type: Schema.Types.ObjectId, ref: "Distribution" }],


### PR DESCRIPTION
Route to create a roadmap plan given a plan (non-roadmap) to copy. Currently does not copy distribution sub-documents as they're not being used. Tested with Postman and MongoDB Compass by visually inspecting results