### PR TITLE
Edit comment getbythread route to use commenter_id from comment schema instead of user schema

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ function createApp() {
   app.use(sisRouter);
   app.use(experimentsRouter);
   app.use(commentRouter);
-  //app.use(roadmapPlanRouter); uncomment when functional or for testing
+  app.use(roadmapPlanRouter);
 
   return app;
 }

--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ const evalRouter = require("./routes/evaluation.js");
 const sisRouter = require("./routes/sisData.js");
 const experimentsRouter = require("./routes/experiments.js");
 const commentRouter = require("./routes/comment.js");
+const roadmapPlanRouter = require("./routes/roadmapPlan.js");
 
 function createApp() {
   const corsOptions = {
@@ -52,6 +53,7 @@ function createApp() {
   app.use(sisRouter);
   app.use(experimentsRouter);
   app.use(commentRouter);
+  //app.use(roadmapPlanRouter); uncomment when functional or for testing
 
   return app;
 }

--- a/model/Comment.js
+++ b/model/Comment.js
@@ -5,7 +5,7 @@ const Schema = mongoose.Schema;
     This model refers to a specific comment(including replies). Every comment belongs to a thread.
 */
 const commentSchema = new Schema({
-  commenter_id: { type: String, ref: "User", required: true },
+  commenter_id: { type: String, required: true },
   visible_user_id: {
     type: [String],
     ref: "User",

--- a/model/RoadmapPlan.js
+++ b/model/RoadmapPlan.js
@@ -9,6 +9,7 @@ const Schema = mongoose.Schema;
 const roadmapPlanSchema = new Schema({
   original: { type: Schema.Types.ObjectId, ref: "Plan" },
   name: { type: String, required: true },
+  description: { type: String },
   majors: { type: [String] },
   tags: { type: [String] },
   num_likes: { type: Number, default: 0 },
@@ -17,7 +18,7 @@ const roadmapPlanSchema = new Schema({
   user_id: { type: String, required: true },
   expireAt: { type: Date },
   postedAt: { type: Date, default: Date.now, required: true },
-  graduatesAt: { type: Date, required: true },
+  graduatesAt: { type: Date },
 });
 
 const RoadmapPlan = mongoose.model("RoadmapPlan", roadmapPlanSchema);

--- a/model/RoadmapPlan.js
+++ b/model/RoadmapPlan.js
@@ -1,0 +1,25 @@
+const mongoose = require("mongoose");
+const Schema = mongoose.Schema;
+
+/*  
+    This model refers to a user plan that has been posted on the roadmap.
+    This is a distinct model from plans that a user has made for themselves
+    on the dashboard.
+*/
+const roadmapPlanSchema = new Schema({
+  original: { type: Schema.Types.ObjectId, ref: "Plan" },
+  name: { type: String, required: true },
+  majors: { type: [String] },
+  tags: { type: [String] },
+  num_likes: { type: Number, default: 0 },
+  year_ids: [{ type: Schema.Types.ObjectId, ref: "Year" }],
+  distribution_ids: [{ type: Schema.Types.ObjectId, ref: "Distribution" }],
+  user_id: { type: String, required: true },
+  expireAt: { type: Date },
+  postedAt: { type: Date, default: Date.now, required: true },
+  graduatesAt: { type: Date, required: true },
+});
+
+const RoadmapPlan = mongoose.model("RoadmapPlan", roadmapPlanSchema);
+
+module.exports = RoadmapPlan;

--- a/model/RoadmapPlan.js
+++ b/model/RoadmapPlan.js
@@ -19,6 +19,8 @@ const roadmapPlanSchema = new Schema({
   expireAt: { type: Date },
   postedAt: { type: Date, default: Date.now, required: true },
   graduatesAt: { type: Date },
+  anonymous: { type: Boolean, default: true, required: true },
+  allowComments: { type: Boolean, default: true, required: true },
 });
 
 const RoadmapPlan = mongoose.model("RoadmapPlan", roadmapPlanSchema);

--- a/model/User.js
+++ b/model/User.js
@@ -9,6 +9,9 @@ const userSchema = new Schema({
   school: { type: String },
   grade: { type: String }, //AE UG Sophomore
   plan_ids: [{ type: Schema.Types.ObjectId, ref: "Plan", default: [] }],
+  liked_roadmap_plans: [
+    { type: Schema.Types.ObjectId, ref: "RoadmapPlan", default: [] },
+  ],
 });
 
 const User = mongoose.model("User", userSchema);

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -18,7 +18,6 @@ router.get("/api/thread/getByPlan/:plan_id", (req, res) => {
         threads[i] = {
           ...threads[i]._doc,
           comments: await Comments.find({ thread_id: threads[i]._id })
-            .populate("commenter_id", "name")
             .sort({ date: 1 })
             .exec(),
         };

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -94,15 +94,22 @@ router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
 // adds one or more tags to the list of tags for this plan
 // tags should be sent as a single string, seperated by commas (with no spaces)
 router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
-  const newTagsStr = req.body.newTags;
-  const newTags = newTagsStr.split(",");
+  let newTags;
   roadmapPlans
-    .findByIdAndUpdate(
-      req.params.plan_id,
-      { $push: { tags: { $each: newTags } } },
-      { new: true }
-    )
-    .then((roadmapPlan) => returnData(roadmapPlanq, res))
+    .findById(req.params.plan_id)
+    .then((plan) => {
+      const newTagsStr = req.body.newTags;
+      newTags = newTagsStr.split(",").filter((elem) => {
+        return !plan.tags.includes(elem);
+      });
+      roadmapPlans
+        .findByIdAndUpdate(
+          req.params.plan_id,
+          { $push: { tags: { $each: newTags } } },
+          { new: true }
+        )
+        .then((roadmapPlan) => returnData(roadmapPlan, res));
+    })
     .catch((err) => errorHandler(res, 404, err));
 });
 

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -136,6 +136,27 @@ router.patch("/api/roadmapPlans/allowComments/:plan_id", (req, res) => {
     .then((found) => returnData(found, res));
 });
 
+router.patch("/api/roadmapPlans/disallowComments/:plan_id", (req, res) => {
+  const plan_id = req.params.plan_id;
+  roadmapPlans
+    .findByIdAndUpdate(plan_id, { allowComments: false })
+    .then((found) => returnData(found, res));
+});
+
+router.patch("/api/roadmapPlans/makeAnonymous/:plan_id", (req, res) => {
+  const plan_id = req.params.plan_id;
+  roadmapPlans
+    .findByIdAndUpdate(plan_id, { anonymous: true })
+    .then((found) => returnData(found, res));
+});
+
+router.patch("/api/roadmapPlans/makeNonAnonymous/:plan_id", (req, res) => {
+  const plan_id = req.params.plan_id;
+  roadmapPlans
+    .findByIdAndUpdate(plan_id, { anonymous: false })
+    .then((found) => returnData(found, res));
+});
+
 // likes/unlikes a roadmap plan
 // user_id required in body
 // returns the number of likes the plan has

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -132,28 +132,28 @@ router.patch("/api/roadmapPlans/removeTags/:plan_id", (req, res) => {
 router.patch("/api/roadmapPlans/allowComments/:plan_id", (req, res) => {
   const plan_id = req.params.plan_id;
   roadmapPlans
-    .findByIdAndUpdate(plan_id, { allowComments: true })
+    .findByIdAndUpdate(plan_id, { allowComments: true }, { new: true })
     .then((found) => returnData(found, res));
 });
 
 router.patch("/api/roadmapPlans/disallowComments/:plan_id", (req, res) => {
   const plan_id = req.params.plan_id;
   roadmapPlans
-    .findByIdAndUpdate(plan_id, { allowComments: false })
+    .findByIdAndUpdate(plan_id, { allowComments: false }, { new: true })
     .then((found) => returnData(found, res));
 });
 
 router.patch("/api/roadmapPlans/makeAnonymous/:plan_id", (req, res) => {
   const plan_id = req.params.plan_id;
   roadmapPlans
-    .findByIdAndUpdate(plan_id, { anonymous: true })
+    .findByIdAndUpdate(plan_id, { anonymous: true }, { new: true })
     .then((found) => returnData(found, res));
 });
 
 router.patch("/api/roadmapPlans/makeNonAnonymous/:plan_id", (req, res) => {
   const plan_id = req.params.plan_id;
   roadmapPlans
-    .findByIdAndUpdate(plan_id, { anonymous: false })
+    .findByIdAndUpdate(plan_id, { anonymous: false }, { new: true })
     .then((found) => returnData(found, res));
 });
 

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -69,6 +69,15 @@ router.get("/api/roadmapPlans/search", (req, res) => {
     .catch((err) => errorHandler(res, 400, err));
 });
 
+// replaces the current plan name with the provided one
+router.patch("/api/roadmapPlans/name/:plan_id", (req, res) => {
+  const newName = req.body.newName;
+  roadmapPlans
+    .findByIdAndUpdate(req.params.plan_id, { name: newName }, { new: true })
+    .then((roadmapPlan) => returnData(roadmapPlan, res))
+    .catch((err) => errorHandler(res, 404, err));
+});
+
 // replaces the current plan description with the provided one
 router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
   const newDesc = req.body.newDesc;
@@ -93,7 +102,7 @@ router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
       { $push: { tags: { $each: newTags } } },
       { new: true }
     )
-    .then((roadmapPlan) => returnData(roadmapPlan, res))
+    .then((roadmapPlan) => returnData(roadmapPlanq, res))
     .catch((err) => errorHandler(res, 404, err));
 });
 

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -78,7 +78,7 @@ router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
       { description: newDesc },
       { new: true }
     )
-    .then((course) => returnData(course, res))
+    .then((roadmapPlan) => returnData(roadmapPlan, res))
     .catch((err) => errorHandler(res, 404, err));
 });
 
@@ -87,6 +87,14 @@ router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
 router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
   const newTagsStr = req.body.newTags;
   const newTags = newTagsStr.split(",");
+  roadmapPlans
+    .findByIdAndUpdate(
+      req.params.plan_id,
+      { $push: { tags: { $each: newTags } } },
+      { new: true }
+    )
+    .then((roadmapPlan) => returnData(roadmapPlan, res))
+    .catch((err) => errorHandler(res, 404, err));
 });
 
 module.exports = router;

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -129,6 +129,13 @@ router.patch("/api/roadmapPlans/removeTags/:plan_id", (req, res) => {
     .catch((err) => errorHandler(res, 404, err));
 });
 
+router.patch("/api/roadmapPlans/allowComments/:plan_id", (req, res) => {
+  const plan_id = req.params.plan_id;
+  roadmapPlans
+    .findByIdAndUpdate(plan_id, { allowComments: true })
+    .then((found) => returnData(found, res));
+});
+
 // likes/unlikes a roadmap plan
 // user_id required in body
 // returns the number of likes the plan has

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -83,8 +83,10 @@ router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
 });
 
 // adds one or more tags to the list of tags for this plan
+// tags should be sent as a single string, seperated by commas (with no spaces)
 router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
-  const newTags = req.body.newTags;
+  const newTagsStr = req.body.newTags;
+  const newTags = newTagsStr.split(",");
 });
 
 module.exports = router;

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -97,4 +97,19 @@ router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
     .catch((err) => errorHandler(res, 404, err));
 });
 
+// removes one or more tags from the list of tags for this plan
+// tags should be sent as a single string, seperated by commas (with no spaces)
+router.patch("/api/roadmapPlans/removeTags/:plan_id", (req, res) => {
+  const tagsStr = req.body.tags;
+  const removals = tagsStr.split(",");
+  roadmapPlans
+    .findByIdAndUpdate(
+      req.params.plan_id,
+      { $pull: { tags: { $in: removals } } },
+      { new: true }
+    )
+    .then((roadmapPlan) => returnData(roadmapPlan, res))
+    .catch((err) => errorHandler(res, 404, err));
+});
+
 module.exports = router;

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -69,4 +69,22 @@ router.get("/api/roadmapPlans/search", (req, res) => {
     .catch((err) => errorHandler(res, 400, err));
 });
 
+// replaces the current plan description with the provided one
+router.patch("/api/roadmapPlans/description/:plan_id", (req, res) => {
+  const newDesc = req.body.newDesc;
+  roadmapPlans
+    .findByIdAndUpdate(
+      req.params.plan_id,
+      { description: newDesc },
+      { new: true }
+    )
+    .then((course) => returnData(course, res))
+    .catch((err) => errorHandler(res, 404, err));
+});
+
+// adds one or more tags to the list of tags for this plan
+router.patch("/api/roadmapPlans/addTags/:plan_id", (req, res) => {
+  const newTags = req.body.newTags;
+});
+
 module.exports = router;

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -1,0 +1,40 @@
+const { returnData, errorHandler } = require("./helperMethods.js");
+const roadmapPlans = require("../model/RoadmapPlan.js");
+const plans = require("../model/Plan.js");
+
+const express = require("express");
+const router = express.Router();
+
+// given the id of a plan already created, generates a roadmapPlan document
+// based on that plan
+router.post("/api/roadmapPlan/createFromPlan", (req, res) => {
+  const old_id = req.body.id;
+  plans
+    .findById(old_id)
+    .then((retrieved) => returnData(createRoadmapPlanFrom(retrieved), res))
+    .catch((err) => errorHandler(res, 400, err));
+});
+
+const createRoadmapPlanFrom = (plan) => {
+  /*let data = {
+    original: plan.id,
+    name: plan.name,
+    majors: plan.majors.slice(),
+    tags: [],
+    user_id: plan.user_id,
+    expireAt: plan.expireAt,
+  };*/
+  console.log(plan);
+  return plan;
+};
+
+// gets and returns a roadmapPlan based on its id
+router.get("/api/roadmapPlans/:plan_id", (req, res) => {
+  const plan_id = req.params.plan_id;
+  roadmapPlans
+    .findByPlanId(plan_id)
+    .then((retrieved) => returnData(retrieved, res))
+    .catch((err) => errorHandler(res, 400, err));
+});
+
+module.exports = router;

--- a/routes/roadmapPlan.js
+++ b/routes/roadmapPlan.js
@@ -7,33 +7,65 @@ const router = express.Router();
 
 // given the id of a plan already created, generates a roadmapPlan document
 // based on that plan
-router.post("/api/roadmapPlan/createFromPlan", (req, res) => {
+router.post("/api/roadmapPlans/createFromPlan", (req, res) => {
   const old_id = req.body.id;
   plans
     .findById(old_id)
-    .then((retrieved) => returnData(createRoadmapPlanFrom(retrieved), res))
+    .then((retrieved) => {
+      let data = {
+        original: retrieved.id,
+        name: retrieved.name,
+        majors: retrieved.majors.slice(),
+        tags: [],
+        user_id: retrieved.user_id,
+        expireAt: retrieved.expireAt,
+      };
+      roadmapPlans
+        .create(data)
+        .then((result) => returnData(result, res))
+        .catch((err) => errorHandler(res, 400, err));
+    })
     .catch((err) => errorHandler(res, 400, err));
 });
 
-const createRoadmapPlanFrom = (plan) => {
-  /*let data = {
-    original: plan.id,
-    name: plan.name,
-    majors: plan.majors.slice(),
-    tags: [],
-    user_id: plan.user_id,
-    expireAt: plan.expireAt,
-  };*/
-  console.log(plan);
-  return plan;
-};
-
 // gets and returns a roadmapPlan based on its id
-router.get("/api/roadmapPlans/:plan_id", (req, res) => {
+router.get("/api/roadmapPlans/get/:plan_id", (req, res) => {
   const plan_id = req.params.plan_id;
   roadmapPlans
-    .findByPlanId(plan_id)
+    .findById(plan_id)
     .then((retrieved) => returnData(retrieved, res))
+    .catch((err) => errorHandler(res, 400, err));
+});
+
+// searches the roadmapPlan documents based on name, description, tags, and
+// major (all optionally)
+router.get("/api/roadmapPlans/search", (req, res) => {
+  // get search queries if they exist
+  const nameSearch = req.query.nameSearch ? req.query.nameSearch : "";
+  const tagSearch = req.query.tagSearch ? req.query.tagSearch : "";
+  const majorSearch = req.query.majorSearch ? req.query.majorSearch : "";
+  let selector = {};
+  // setup search for name and description
+  if (nameSearch !== "") {
+    selector["$or"] = [
+      { name: { $regex: nameSearch, $options: "i" } },
+      { description: { $regex: nameSearch, $options: "i" } },
+    ];
+  }
+  // setup search for tags
+  /*if (tagSearch !== "") {
+    let splitTags = tagSearch.split(" ");
+    let tagQuery = [];
+    splitTags.forEach((elem) => tagQuery.push({ $regex: elem, $options: "i" }));
+    selector["tags"] = { $all: tagQuery };
+  }*/
+  // setup search for majors
+  if (majorSearch !== "") {
+    selector["majors"] = majorSearch;
+  }
+  roadmapPlans
+    .find(selector)
+    .then((result) => returnData(result, res))
     .catch((err) => errorHandler(res, 400, err));
 });
 


### PR DESCRIPTION
Edit comment getbythread route to use commenter_id from the comment schema instead of referencing "name" in user schema

Getting "name" from the user schema is redundant since comment has commenter_id already.