### PR TITLE
DEV-49 fix SISCS.find() timeout; replace with distinct()

### DIFF
--- a/routes/search.js
+++ b/routes/search.js
@@ -156,19 +156,16 @@ function sendCourseVersion(query, version, res) {
 }
 
 router.get("/api/getYearRange", (req, res) => {
-  SISCV.find().then((resp) => {
+  SISCV.distinct("terms").then((resp) => {
     let years = { min: Infinity, max: -Infinity };
-    resp.forEach((course) => {
-      course.terms.forEach((term) => {
-        if (parseInt(term.substring(term.length - 4, term.length)) < years.min)
-          years.min = parseInt(term.substring(term.length - 4, term.length));
-        if (parseInt(term.substring(term.length - 4, term.length)) > years.max)
-          years.max = parseInt(term.substring(term.length - 4, term.length));
-      });
-    });
-
+    resp.forEach((term) => {
+      if (parseInt(term.substring(term.length - 4, term.length)) < years.min)
+        years.min = parseInt(term.substring(term.length - 4, term.length));
+      if (parseInt(term.substring(term.length - 4, term.length)) > years.max)
+        years.max = parseInt(term.substring(term.length - 4, term.length));
+    })
     returnData(years, res);
-  });
+  }); 
 });
 
 module.exports = router;


### PR DESCRIPTION
## Problem
/api/getYearRange always times out and return 504 
This also happens very often aka everytime someone loads /dashboard and the localStorage does not have yearRange 

## Context 
this route returns the minimum and maximum years of courses by iterating through ALL the documents in the SISCV collection. Frontend sets yearRange in localStorage to store these values; needed to know which options to display for year select during course search. 

Called often** everytime someone loads /dashboard and the localStorage does not have yearRange 

## Cause 
we have over 6500 course documents in the collection. Best case, find({}) takes 6 minutes. Worst case, it times out and returns 504. It might be what crashes our backend too. 

## Fix 
use [distinct()](https://www.mongodb.com/docs/manual/reference/method/db.collection.distinct/#mongodb-method-db.collection.distinct) instead of find() 

