### PR TITLE
DEV-51: fix bug in /api/planReview/changeStatus

### DIFF
--- a/routes/planReview.js
+++ b/routes/planReview.js
@@ -163,8 +163,8 @@ router.post("/api/planReview/changeStatus", (req, res) => {
       } else {
         review.status = status;
         if (status === "UNDERREVIEW") review.requestTime = Date.now();
-        const reviewer = await users.findById(reviewer_id);
-        const reviewee = await users.findById(reviewee_id);
+        const reviewer = await users.findById(review.reviewer_id);
+        const reviewee = await users.findById(review.reviewee_id);
         await sendReviewMail(
           reviewee.name,
           reviewer.name,


### PR DESCRIPTION
## Problem
Accepting and rejecting plan in plan summary does not work. To recreate bug: 
Login as mliu78 and preview a reviewee's plan. Clicking on the approve or reject button will do nothing. 

## Context
The buttons call the `/api/planReview/changeStatus` route. It's been returning 500. 

## Fix
```
        const reviewer = await users.findById(review.reviewer_id);
        const reviewee = await users.findById(review.reviewee_id);
```
we were missing the `review.`