### PR TITLE
DEV-55: dev branch connect to dev database

### DIFF
--- a/data/db.js
+++ b/data/db.js
@@ -2,10 +2,8 @@ require("dotenv").config(); //search for env variables
 const mongoose = require("mongoose");
 
 //set up db connection link
-const password = process.env.DB_ADMIN_PASSWORD;
-const dbname = "ucredit-db";
 const debug = process.env.DEBUG === "True";
-const URI = debug ? "mongodb://db:27017/debug" : `mongodb+srv://ucredit-admin:${password}@cluster0.ccsle.mongodb.net/${dbname}?retryWrites=true&w=majority`;
+const URI = debug ? "mongodb://db:27017/debug" : process.env.URI; 
 //config connect options
 const option = {
   useNewUrlParser: true,


### PR DESCRIPTION
# dev branch now has its own database

## Changes 
- new mongo cluster called `ucredit-dev`
- db.js establishes connection with the URI hardcoded in .env 

## Why are we doing this? 
- no more 'accidentally' connecting to production db 
- gives developers one dev db to mess around with 
- more secure as URI is in .env (only developers have access)

# What you should know 
- the new db
    - has courses, majors and nothing else 
    - You can easily create a new user for yourself by using backdoor auth 
    - Your plan will not be there nor can you import from production
    - let me know if there is data we /should/ copy over 
- head over to notion and copy the new .env file for DEVELOPMENT
- you can still access your local docker container using debug=true 
- if this PR gets merged to dev, all of us will need to update out .env 
- if this PR makes it to main, we need to update .env in heroku / render 