### PR TITLE
DEV-48 + 66: scripts to add level/version field to courses

### DIFF
--- a/data/addFieldsToCollection.js
+++ b/data/addFieldsToCollection.js
@@ -7,10 +7,13 @@
 const db = require("./db");
 const plans = require("../model/Plan.js");
 const users = require("../model/User.js");
+const courses = require("../model/Course.js"); 
+const SISCV = require("../model/SISCourseV"); 
 
 //addFieldsToCollection(users);
 //updateFieldsInCollection(plans, {}, { reviewers: [] });
 //updateFieldsInCollection(users, {}, { whitelisted_plan_ids: [] });
+setLevelInCourses();
 
 async function addFieldsToCollection(model) {
   await db.connect();
@@ -37,4 +40,44 @@ async function updateFieldsInCollection(model, matchCriteria, modification) {
     console.log(res.matchedCount, "documents matched.");
     console.log(res.modifiedCount, "documents modified.");
   });
+}
+
+/* 
+  Script to add the 'level' field based on the matching SISCourseV document 
+  To update courses prior to the schema change (added new level field)
+*/ 
+async function setLevelInCourses() {
+  await db.connect();
+  let updated = 0; 
+  // find courses without a level field 
+  courses.find({ level: { $exists: false } }).then(async (res) => {
+    console.log(res.length);
+    for (let course of res) {
+      let courseFromDB = await SISCV.findOne({
+        number: course.number,
+        title: course.title,
+      }).exec();
+      if (courseFromDB) {
+        // update based on SIS course if available 
+        updated++; 
+        course.level = courseFromDB.versions[0].level; 
+      } else {
+        // update based on course number 
+        if (course.number && course.number.length > 7 && !isNaN(course.number[7])) {
+          if (course.number[7] <= '2') {
+            course.level = "Lower Level Undergraduate"
+          } else {
+            course.level = "Upper Level Undergraduate"
+          } 
+        } else {
+          course.level = "Lower Level Undergraduate"
+        }
+      }
+      console.log(course.title + ": " + course.level);
+      course.save(); 
+    } 
+    console.log('matched: %d', res.length); 
+    console.log('updated from SISCourseV: %d', updated); 
+    console.log('updated from course number: %d', res.length - updated); 
+  }); 
 }

--- a/data/addFieldsToCollection.js
+++ b/data/addFieldsToCollection.js
@@ -9,11 +9,13 @@ const plans = require("../model/Plan.js");
 const users = require("../model/User.js");
 const courses = require("../model/Course.js"); 
 const SISCV = require("../model/SISCourseV"); 
+const years = require("../model/Year.js");
 
 //addFieldsToCollection(users);
 //updateFieldsInCollection(plans, {}, { reviewers: [] });
 //updateFieldsInCollection(users, {}, { whitelisted_plan_ids: [] });
-setLevelInCourses();
+// setLevelInCourses();
+setVersionInCourses();
 
 async function addFieldsToCollection(model) {
   await db.connect();
@@ -79,5 +81,28 @@ async function setLevelInCourses() {
     console.log('matched: %d', res.length); 
     console.log('updated from SISCourseV: %d', updated); 
     console.log('updated from course number: %d', res.length - updated); 
+  }); 
+}
+
+
+/* 
+  Script to add the 'version' field based on term and year fields 
+*/ 
+async function setVersionInCourses() {
+  await db.connect();
+  let updated = 0; 
+  courses.find({ version: { $exists: false } }).then(async (res) => {
+    console.log(res.length);
+    for (let course of res) {
+      updated++; 
+      let version = course.term.toLowerCase(); 
+      const year = await years.findById(course.year_id);
+      version = version.charAt(0).toUpperCase() + version.slice(1) + " " + year.year;
+      course.version = version; 
+      console.log(course.title + ": " + course.version);
+      course.save(); 
+    }
+    console.log('matched: %d', res.length); 
+    console.log('updated: %d', updated); 
   }); 
 }


### PR DESCRIPTION
## bug 1
import plan fails, specifically with plans created more than 3 months ago 
example: https://ucredit.me/share?_id=61e644ff68480b0004c9e6e9

error message for POST /api/courses/: 
`course validation failed: path 'level' is required`

3 months ago there was a schema change to add level field to course 
all course objects created prior to that do not have level field even though it's required 

## bug 2
courses in imported plans do not have a version field 
causes frontend to crash `reading property toLowerCase() of undefined...` 
we're simply missing that field in the POST api call 

## fix 
update Courses collections such that all course documents have a level field (either based on corresponding SIS course document OR based on course number) 
likewise for version field; update based on term and year object associated 

before 
<img width="906" alt="Screen Shot 2022-11-05 at 4 17 37 PM" src="https://user-images.githubusercontent.com/90944895/200141346-5a4dfc78-d9b3-487b-8372-8add3f0394ec.png">
after 
<img width="912" alt="Screen Shot 2022-11-05 at 4 56 50 PM" src="https://user-images.githubusercontent.com/90944895/200141348-93fc3e91-7970-4db8-8fc2-fc17acf95954.png">


