### PR TITLE
DEV-43: changes to deploy api on onrender

### DIFF
--- a/routes/experiments.js
+++ b/routes/experiments.js
@@ -9,11 +9,11 @@ const experiments = new ExperimentDao();
 
 // health check path that allows render to confirm server is up 
 // restart app automatically if unresponsive or errors
-router.get("/api/test", (req, res) => {
+router.get("/", (req, res) => {
   // simple fail proof db query 
   majors
     .findOne({})
-    .then((major) => returnData(major, res))
+    .then((major) => returnData("Welcome to uCredit backend!", res))
     .catch((err) => errorHandler(res, 500, err));
 });
 

--- a/routes/experiments.js
+++ b/routes/experiments.js
@@ -1,13 +1,20 @@
 const express = require("express");
 const ExperimentDao = require("../data/ExperimentDao");
 const ApiError = require("../model/ApiError");
+const majors = require("../model/Major.js");
 const { returnData } = require("./helperMethods.js");
 
 const router = express.Router();
 const experiments = new ExperimentDao();
 
+// health check path that allows render to confirm server is up 
+// restart app automatically if unresponsive or errors
 router.get("/api/test", (req, res) => {
-  returnData("test passed", res);
+  // simple fail proof db query 
+  majors
+    .findOne({})
+    .then((major) => returnData(major, res))
+    .catch((err) => errorHandler(res, 500, err));
 });
 
 router.get("/api/experiments/allExperiments", async (req, res, next) => {

--- a/routes/experiments.js
+++ b/routes/experiments.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const ExperimentDao = require("../data/ExperimentDao");
 const ApiError = require("../model/ApiError");
+const { returnData } = require("./helperMethods.js");
 
 const router = express.Router();
 const experiments = new ExperimentDao();

--- a/routes/experiments.js
+++ b/routes/experiments.js
@@ -5,6 +5,10 @@ const ApiError = require("../model/ApiError");
 const router = express.Router();
 const experiments = new ExperimentDao();
 
+router.get("/api/test", (req, res) => {
+  returnData("test passed", res);
+});
+
 router.get("/api/experiments/allExperiments", async (req, res, next) => {
   try {
     const data = await experiments.retrieveAll();

--- a/routes/sso.js
+++ b/routes/sso.js
@@ -18,8 +18,8 @@ const PvK = process.env.PRIVATE_KEY;
 const DEBUG = process.env.DEBUG === "True";
 
 const JHU_SSO_URL = "https://idp.jh.edu/idp/profile/SAML2/Redirect/SSO";
-const SP_NAME = "https://ucredit-api.herokuapp.com";
-const BASE_URL = "https://ucredit-api.herokuapp.com";
+const SP_NAME = "https://ucredit-api.onrender.com";
+const BASE_URL = "https://ucredit-api.onrender.com";
 
 const displayName = "urn:oid:2.16.840.1.113730.3.1.241";
 const grade = "user_field_job_title";


### PR DESCRIPTION
## changes 
- in sso.js, callback url after SAML authentication defaults to new onrender.com deployment 
- added new /api/test route that render.com can check to see if deployment is live and healthy 

## todos 
- merge current PR into backend dev and this [PR](https://github.com/uCredit-Dev/ucredit_frontend_typescript/pull/387) into frontend development branch 
- test for a week 
- merge dev into backend main and development into frontend master

ucredit-dev: [https://ucredit-dev.onrender.com](https://ucredit-dev.onrender.com) is a deployment of the [DEV-43](https://github.com/uCredit-Dev/uCredit-API/tree/DEV-43) branch 
ucredit-api: [https://ucredit-apii.onrender.com](https://ucredit-api.onrender.com) is a deployment of the [main](https://github.com/uCredit-Dev/uCredit-API/tree/main) branch 
