### PR TITLE
DEV-89: expireAt field is a TTL index

### DIFF
--- a/model/Course.js
+++ b/model/Course.js
@@ -37,7 +37,7 @@ const courseSchema = new Schema({
   user_id: { type: String, required: true },
   level: { type: String, required: true },
   forceSatisfied: { type: String, required: false },
-  expireAt: { type: Date },
+  expireAt: { type: Date,  expires: 60*60*24 },
 });
 
 //custom static model functions

--- a/model/Distribution.js
+++ b/model/Distribution.js
@@ -17,7 +17,7 @@ const distributionSchema = new Schema({
   courses: [{ type: Schema.Types.ObjectId, ref: "Course" }],
   user_id: { type: String, required: true },
   plan_id: { type: Schema.Types.ObjectId, ref: "Course", required: true },
-  expireAt: { type: Date },
+  expireAt: { type: Date,  expires: 60*60*24 },
 });
 
 distributionSchema.statics.findByName = function (name, user_id) {

--- a/model/Plan.js
+++ b/model/Plan.js
@@ -11,7 +11,7 @@ const planSchema = new Schema({
   year_ids: [{ type: Schema.Types.ObjectId, ref: "Year" }],
   distribution_ids: [{ type: Schema.Types.ObjectId, ref: "Distribution" }],
   user_id: { type: String, required: true },
-  expireAt: { type: Date },
+  expireAt: { type: Date,  expires: 60*60*24 },
 });
 
 const Plan = mongoose.model("Plan", planSchema);

--- a/model/Year.js
+++ b/model/Year.js
@@ -6,7 +6,7 @@ const yearSchema = new Schema({
   courses: [{ type: Schema.Types.ObjectId, ref: "Course" }],
   plan_id: [{ type: Schema.Types.ObjectId, ref: "Plan", required: true }],
   user_id: { type: String, required: true },
-  expireAt: { type: Date },
+  expireAt: { type: Date,  expires: 60*60*24 },
   year: { type: Number, required: false },
 });
 

--- a/routes/plan.js
+++ b/routes/plan.js
@@ -109,7 +109,7 @@ router.post("/api/plans", (req, res) => {
           year: i === 0 ? 0 : startYear + i,
           expireAt:
             retrievedPlan.user_id === "guestUser"
-              ? Date.now() + 60 * 60 * 24 * 1000
+              ? Date.now()
               : undefined,
         };
         const newYear = await years.create(retrievedYear);


### PR DESCRIPTION
## problem 
too many outdated guestUser documents in db that slow our db queries  

## goal
The course, distribution, plan, and year documents **belonging to guestUser** should expire 24 hours after their creation. 

## implementation
The expireAt field is now a [TTL index](https://www.mongodb.com/docs/manual/core/index-ttl/). 
- At document creation, expireAt = `Date.now()` and expires specifies that it should expire at `Date.now() + 60*60*24`. 
- Importantly, expireAt is only defined for documents related to guestUser. `{ user_id: "guestUser" }`

also see: https://github.com/uCredit-Dev/ucredit_frontend_typescript/pull/414
