### PR TITLE
DEV-44: revise search route

### DIFF
--- a/data/db.js
+++ b/data/db.js
@@ -13,7 +13,6 @@ const URI = debug ? "mongodb://db:27017/debug" : process.env.URI;
 
 //establish connection to cloud database
 export async function connect() {
-  console.log(URI);
   mongoose.connect(URI);
 
   //handle events emitted by the connection process

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 import { connect } from "./data/db.js";
 import { createApp } from "./app.js";
 import dotenv from "dotenv";
+import mongoose from "mongoose";
 
 dotenv.config();
 const port = process.env.PORT || 4567;
 
 //launch api
+mongoose.set('strictQuery', true); 
 connect();
 const app = createApp();
 app.listen(port, () => {

--- a/routes/course.js
+++ b/routes/course.js
@@ -217,25 +217,25 @@ router.patch("/api/courses/dragged", auth, async (req, res) => {
             { new: true, runValidators: true }
           ); 
         // add course to new year
-        const y = await years
+        const year = await years
           .findByIdAndUpdate(
             newYear_id,
             { $push: { courses: c_id } },
             { new: true, runValidators: true }
           ); 
-        const c = await courses
+        const course = await courses
           .findByIdAndUpdate(
             c_id,
             {
-              year: y.name,
-              year_id: y._id,
+              year: year.name,
+              year_id: year._id,
               term: newTerm.toLowerCase(),
               version:
-                newTerm + " " + (newTerm === "Fall" ? y.year : y.year + 1),
+                newTerm + " " + (newTerm === "Fall" ? year.year : year.year + 1),
             },
             { new: true, runValidators: true }
           ); 
-        returnData(c, res);
+        returnData(course, res);
       }
     } catch (err) {
       errorHandler(res, 500, err.message); 

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -61,23 +61,28 @@ async function postNotification(message, user_id, quick_link_id, link_type) {
   return n;
 }
 
+// return an array of substrings of length 3+
 function ngram(query) {
   const MIN_LEN = 3; 
   const queryLen = query.length; 
   query = query.toLowerCase();
   const ngrams = new Set();
   ngrams.add(query);
+  // add substrings from largest to smallest 
   for (let substrLen = queryLen; substrLen >= MIN_LEN; substrLen--) {
     for (let i = 0; i <= queryLen - substrLen; i++) {
       ngrams.add(query.slice(i, i + substrLen)); 
     }
   }
+  // make array from set 
   return Array.from(ngrams);
 }
 
+// for strict query matching 
 async function simpleSearch(query, page) {
   const PERPAGE = 10; 
   const result = {}; 
+  // set pagination info; limit to 100 
   const total = await SISCV.countDocuments(query).exec(); 
   result.pagination = {
     page: page, 
@@ -85,11 +90,12 @@ async function simpleSearch(query, page) {
     last: total <= 100 ? Math.ceil(total / PERPAGE) : 10, 
     total: total
   }
-  let courses = await SISCV.find(query).skip((page) * PERPAGE).limit(PERPAGE); 
-  result.courses = courses; 
+  // skip and limit according to page 
+  result.courses = await SISCV.find(query).skip((page) * PERPAGE).limit(PERPAGE); 
   return result; 
 }
 
+// search for all courses matching substring of searchTerm  
 async function fuzzySearch(query, searchTerm, page) {
   const PERPAGE = 10; 
   const result = {};
@@ -98,11 +104,12 @@ async function fuzzySearch(query, searchTerm, page) {
     gram = gram.replace('.', '\\.'); 
     return new RegExp(gram);
   });
-  // TODO: index title and number 
+  // query for title / number matching any of the RegExps
   query['$or'] = [
     { title: { $in: regNgrams } },
     { number: { $in: regNgrams } },
   ]; 
+  // return pagination information; limit to 100 
   const total = await SISCV.countDocuments(query).exec(); 
   result.pagination = {
     page: page, 
@@ -110,7 +117,9 @@ async function fuzzySearch(query, searchTerm, page) {
     last: total <= 100 ? Math.ceil(total / PERPAGE) : 10, 
     total: total <= 100 ? total : 100, 
   }
+  // query for courses
   let courses = await SISCV.find(query); 
+  // calculate priority; summate the matching substring lengths 
   courses.forEach((course, i) => {
     for (let gram of ngrams) {
       if (course.title.toLowerCase().includes(gram) || course.number.toLowerCase().includes(gram)) {
@@ -118,20 +127,101 @@ async function fuzzySearch(query, searchTerm, page) {
       }
     }
   });
+  // sort by descending priority 
   courses = courses.sort((c1, c2) => c2.priority - c1.priority); 
+  // skip and limit according to page 
   result.courses = courses.slice(page * PERPAGE, (page + 1) * PERPAGE); 
   return result; 
 }
 
+// return true if userCourse is offered in newTerm 
 const checkDestValid = (sisCourses, userCourse, newTerm) => {
   for (let sisC of sisCourses) {
     if (sisC.number === userCourse.number) {
       for (let term of sisC.terms) {
+        // example: "Fall 2021" includes "Fall"
         if (term.includes(newTerm)) return true; 
       }
     }
   }
   return false; 
+}
+
+function constructQuery(params) {
+  let {
+    userQuery = "",
+    school = "",
+    department = "",
+    term = "",
+    areas = "",
+    wi,
+    credits = "",
+    tags = "",
+    level = "",
+  } = params;
+  userQuery = userQuery.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&"); //escape special character for regex
+  let query = {
+    $or: [
+      { title: { $regex: userQuery, $options: "i" } },
+      { number: { $regex: userQuery, $options: "i" } },
+    ],
+    "versions.school": { $regex: school, $options: "i" },
+    "versions.department": { $regex: department, $options: "i" },
+    "versions.term": { $regex: term, $options: "i" },
+    "versions.level": { $regex: level, $options: "i" },
+  };
+  if (areas !== "" && areas !== "None") {
+    query["versions.areas"] = {
+      $not: new RegExp("None"), 
+      $in: areas.split("|").map((area) => new RegExp(area)),
+    };
+  }
+
+  if (tags !== "") {
+    query["versions.tags"] = {
+      $in: tags.split("|").map((tag) => new RegExp(tag)),
+    };
+  }
+
+  if (credits !== "") {
+    query["versions.credits"] = {
+      $in: credits.split("|"),
+    };
+  }
+
+  if (wi != null) {
+    if (wi === "1" || wi === "true") {
+      query["versions.wi"] = true;
+    } else if (wi === "0" || wi === "false") {
+      query["versions.wi"] = false;
+    }
+  }
+  return query;
+}
+
+async function sendCourseVersion(query, version, res) {
+  const match = await SISCV.findOne(query); 
+  if (match == null) {
+    return errorHandler(
+      res,
+      404,
+      "Did not find any course or the course specified is not offered in this term."
+    );
+  } 
+  try {
+    let course = {};
+    course.title = match.title;
+    course.number = match.number;
+    course.terms = match.terms;
+    match.versions.forEach((v) => {
+      if (v.term === version) {
+        course.version = v;
+      }
+    });
+    returnData(course, res);
+  } catch (err) {
+    errorHandler(res, 400, err); 
+  }
 }
 
 export {
@@ -143,4 +233,6 @@ export {
   simpleSearch,
   fuzzySearch,
   checkDestValid,
+  constructQuery, 
+  sendCourseVersion
 };

--- a/routes/helperMethods.js
+++ b/routes/helperMethods.js
@@ -2,6 +2,9 @@
 import Notifications from "../model/Notification.js";
 import SISCV from "../model/SISCourseV.js"; 
 
+const PERPAGE = 10; 
+const MIN_LEN = 3; 
+
 //add data field to the response object. If data is null, return 404 error
 function returnData(data, res) {
   data
@@ -63,7 +66,6 @@ async function postNotification(message, user_id, quick_link_id, link_type) {
 
 // return an array of substrings of length 3+
 function ngram(query) {
-  const MIN_LEN = 3; 
   const queryLen = query.length; 
   query = query.toLowerCase();
   const ngrams = new Set();
@@ -80,7 +82,6 @@ function ngram(query) {
 
 // for strict query matching 
 async function simpleSearch(query, page) {
-  const PERPAGE = 10; 
   const result = {}; 
   // set pagination info; limit to 100 
   const total = await SISCV.countDocuments(query).exec(); 
@@ -97,7 +98,6 @@ async function simpleSearch(query, page) {
 
 // search for all courses matching substring of searchTerm  
 async function fuzzySearch(query, searchTerm, page) {
-  const PERPAGE = 10; 
   const result = {};
   const ngrams = ngram(searchTerm);
   const regNgrams = ngrams.map((gram) => {

--- a/routes/notification.js
+++ b/routes/notification.js
@@ -14,7 +14,6 @@ router.get("/api/notifications/:user_id", auth, (req, res) => {
   if (!user_id) {
     errorHandler(res, 400, { message: "Must provide user_id." });
   } else {
-    console.log(user_id);
     Notifications.find({ user_id: { $elemMatch: { $eq: user_id } } })
       .then((notifications) => {
         returnData(notifications, res);


### PR DESCRIPTION
Frontend PR: https://github.com/uCredit-Dev/ucredit_frontend_typescript/pull/430 
# Revise search route 
- `api/search/` 
  - simple search or fuzzy search depending on length of query 
  - returns up to 10 course objects with pagination info 
  - query is precise, meaning less filtering in frontend 
- `api/coursesByPlan/:plan_id` 
  - will (hopefully) replace unnecessary `api/search/:course_number` api calls 
- `/api/courses/dragged` 
  - do the `no course this semester` check in the route

# Rationale
Searching for courses is currently slow or results in an excessive amount of API calls. For example, 
- search for 'd' 
  -  takes 10+ seconds to return **1091** courses! 
- search for 'introductory chem' 
  - makes **55** api calls with various substrings of the query 

We also suspect that backend is prone to crashing because we store thousands of course documents in local variables! 
> FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory  ....  Error: error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode

# Implementation 
- tried to make use of [MongoDB Atlas Search](https://www.mongodb.com/docs/atlas/atlas-search/text/#fuzzy-examples) but could not get the desired search result :(
  - but difference in latency is negligible
- if searchTerm is <= 3 letters, simpleSearch (exact match)
- else: 
  - split searchTerm into substrings and match document titles / numbers to an array of RegExprs
  - for each course, calculate priority by 1) number and 2) length of the substring matches
  - sort by priority and paginate 

# Testing
- tested course search, cart search, and drag drop locally 