### PR TITLE
DEV-52 switching year value for years crashes app

### DIFF
--- a/routes/year.js
+++ b/routes/year.js
@@ -116,7 +116,7 @@ router.patch("/api/years/updateYear", auth, async (req, res) => {
   }
   try {
     // check that year belongs to user
-    const retrievedYear = await Years.findById(year_id).exec();
+    const retrievedYear = await Years.findById(year_id).populate("courses").exec();
     if (req.user._id !== retrievedYear.user_id) {
       return forbiddenHandler(res);
     }


### PR DESCRIPTION
Note: This used to be Akhil's task but I stole it.

### Description
For a year that has courses (nonempty year), switching the year value causes an "Application error: a client-side exception has occurred (see the browser console for more information)."

### Implementation
Changed one line in routes/year.js from 'const retrievedYear = await Years.findById(year_id).exec();' to 'const retrievedYear = await Years.findById(year_id).populate("courses").exec();'.

### Testing
Tested locally. Tried changing year values, no errors occurred.