### PR TITLE
Dev 125, fix: cannot add same course to same semester

### DIFF
--- a/routes/course.js
+++ b/routes/course.js
@@ -113,8 +113,10 @@ router.post("/api/courses", auth, async (req, res) => {
         });
     });
     const retrievedCourses = await Courses.findByPlanId(course.plan_id); 
-    for (let existingCourse of retrievedCourses) {
-      if(existingCourse.number === course.number && existingCourse.version=== course.version && existingCourse.title ===course.title){
+    console.log(course);
+    for (const existingCourse of retrievedCourses) {
+      console.log(existingCourse);
+      if(existingCourse.number === course.number && existingCourse.term === course.term && existingCourse.year === course.year && existingCourse.title === course.title){
         return errorHandler(res, 400, { 
           message: "Cannot take same course multiple times in the same semester",
         });

--- a/routes/course.js
+++ b/routes/course.js
@@ -113,9 +113,7 @@ router.post("/api/courses", auth, async (req, res) => {
         });
     });
     const retrievedCourses = await Courses.findByPlanId(course.plan_id); 
-    console.log(course);
     for (const existingCourse of retrievedCourses) {
-      console.log(existingCourse);
       if(existingCourse.number === course.number && existingCourse.term === course.term && existingCourse.year === course.year && existingCourse.title === course.title){
         return errorHandler(res, 400, { 
           message: "Cannot take same course multiple times in the same semester",

--- a/routes/course.js
+++ b/routes/course.js
@@ -112,6 +112,14 @@ router.post("/api/courses", auth, async (req, res) => {
           message: "Invalid combination of plan_id and distribution_ids.",
         });
     });
+    const retrievedCourses = await Courses.findByPlanId(course.plan_id); 
+    for (let existingCourse of retrievedCourses) {
+      if(existingCourse.number === course.number && existingCourse.version=== course.version && existingCourse.title ===course.title){
+        return errorHandler(res, 400, { 
+          message: "Cannot take same course multiple times in the same semester",
+        });
+      }
+    }
     // create course and update distributiosn
     const retrievedCourse = await Courses.create(course);
     for (let id of retrievedCourse.distribution_ids) {

--- a/routes/course.js
+++ b/routes/course.js
@@ -108,7 +108,7 @@ router.post("/api/courses", auth, async (req, res) => {
     const plan = await Plans.findById(course.plan_id).exec();
     course.distribution_ids.forEach((id) => {
       if (!plan.distribution_ids.includes(id))
-        errorHandler(res, 400, {
+        errorHandler(res, 500, {
           message: "Invalid combination of plan_id and distribution_ids.",
         });
     });
@@ -140,7 +140,7 @@ router.post("/api/courses", auth, async (req, res) => {
       .exec();
     returnData(retrievedCourse, res);
   } catch (err) {
-    errorHandler(res, 400, err);
+    errorHandler(res, 500, err);
   }
 });
 

--- a/tests/routes/course.spec.js
+++ b/tests/routes/course.spec.js
@@ -261,22 +261,22 @@ describe("Course Routes: POST /api/courses", () => {
     expect(res.status).toBe(403);
   });
 
-  it("Should return status 400 for undefined body", async () => {
+  it("Should return status 500 for undefined body", async () => {
     const res = await request
       .post(`/api/courses/`)
       .set("Authorization", `Bearer ${TEST_TOKEN_1}`);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
   });
 
-  it("Should return status 400 for empty body", async () => {
+  it("Should return status 500 for empty body", async () => {
     const res = await request
       .post(`/api/courses/`)
       .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
       .send({});
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
   });
 
-  it("Should return status 400 for incomplete body", async () => {
+  it("Should return status 500 for incomplete body", async () => {
     // course body missing plan_id
     const course = SAMEPLE_COURSES[0];
     delete course.plan_id;
@@ -285,10 +285,10 @@ describe("Course Routes: POST /api/courses", () => {
       .post(`/api/courses/`)
       .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
       .send(course);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
   });
 
-  it("Should return status 400 for mismatch between plan_id and distribution_ids", async () => {
+  it("Should return status 500 for mismatch between plan_id and distribution_ids", async () => {
     // set request course body
     const course = SAMEPLE_COURSES[0];
     course.distribution_ids = [VALID_ID]; // random objectid
@@ -297,7 +297,7 @@ describe("Course Routes: POST /api/courses", () => {
       .post(`/api/courses/`)
       .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
       .send(course);
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(500);
   });
 });
 

--- a/tests/routes/course.spec.js
+++ b/tests/routes/course.spec.js
@@ -465,6 +465,22 @@ describe("Course Routes: PATCH /api/courses/dragged", () => {
     expect(res.status).toBe(400);
   });
 
+  it("Should return status 400 for trying to add identical course twice", async () => {
+    courses = await Courses.find({});
+    let course = courses[0];
+    const res = await request
+      .post(`/api/courses/`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
+      .send(course);
+    expect(res.status).toBe(200);
+    const res2 = await request
+      .post(`/api/courses/`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
+      .send(course);
+    expect(res2.status).toBe(400);
+
+  });
+
   it("Should return status 400 for undefined id", async () => {
     courses = await Courses.find({});
     let course = courses[0];


### PR DESCRIPTION
**Description:**
UCredit users could previously add the same course to their schedules multiple times in the same semester, which should not be allowed. The solution is to not add the course when someone tries adding a duplicate course.

**Implementation:**
In the file for course routes, when a user tries to add a course, the api first pulls a list of the courses in the plan, and checks if any courses match in title, version, and course number. If so, the course will not be added and an error will be thrown.

**Testing:**
Wrote a unit test that tries to add sample course twice, and made sure the second attempt fails. Also did local testing.