### PR TITLE
DEV-157: Prevent users from duplicating courses through drag and drop

### DIFF
--- a/routes/course.js
+++ b/routes/course.js
@@ -211,23 +211,18 @@ router.patch('/api/courses/dragged', auth, async (req, res) => {
         });
       }
       // check if course is a duplicate at new term!
-      const retrievedCourses = await Courses.findByPlanId(course.plan_id);
-      for (const existingCourse of retrievedCourses) {
-        if (
-          existingCourse.number === course.number &&
-          existingCourse.term === newTerm.toLowerCase() &&
-          existingCourse.year === newYear.name &&
-          existingCourse.title === course.title
-        ) {
-          console.log(newTerm);
-          console.log(existingCourse.term);
-          console.log(newYear.name);
-          console.log(existingCourse.year);
-          return errorHandler(res, 400, {
-            message:
-              'Cannot take same course multiple times in the same semester',
-          });
-        }
+      const retrievedCourses = await Courses.find({
+        plan_id: course.plan_id,
+        number: course.number,
+        term: newTerm.toLowerCase(),
+        title: course.title,
+        year: newYear.name,
+      });
+      if (retrievedCourses.length !== 0) {
+        return errorHandler(res, 400, {
+          message:
+            'Cannot take same course multiple times in the same semester',
+        });
       }
       // remove course from old year
       await Years.findByIdAndUpdate(


### PR DESCRIPTION
## Description
Drag and drop duplicate course should not be allowed.

## Implementation
I have added a new check in the `routes/course.js` file to identify duplicate courses after drag and drop within the same term and year. This check is implemented using the same approach as the one used in the POST route for /api/courses.

## Testing
I tested locally and ensured everything works as expected.