### PR TITLE
Dev 147: Update course should be its own route

### DIFF
--- a/data/replaceOldMajors.js
+++ b/data/replaceOldMajors.js
@@ -1,0 +1,80 @@
+import { connect } from "./db.js";
+import User from '../model/User.js';
+import Plan from '../model/Plan.js';
+
+async function replaceOldWithNew() {
+  connect();
+
+  const users = await User.find({});
+  for (let user of users) {
+    for (let plan_id of user.plan_ids) {
+      let plan = await Plan.findById(plan_id).exec();
+      if (plan !== null && plan.majors != null && plan.majors.length > 0) {
+        // console.log("before: " + plan.majors);
+        for (let ind in plan.majors) {
+          let major = plan.majors[ind];
+          if (major.includes("B.A. Computer Science (NEW - 2021 & after)")) {
+            plan.majors[ind] = "B.A. Computer Science";
+          } else if (major.includes("B.S. Computer Science (OLD - Pre-2021)") 
+          || major.includes("B.S. Computer Science (NEW - 2021 & after)")) {
+            plan.majors[ind] = "B.S. Computer Science";
+          } else if (major.includes("Minor Computer Science (OLD - Pre-2021)")) {
+            plan.majors[ind] = "Minor Computer Science";
+          } else if (major.includes("Minor Computer Science (NEW - 2021 & after)")) {
+            plan.majors[ind] = "Minor Computer Science";
+          } else if (major.includes("Minor Applied Mathematics & Statistics (OLD - Pre-2021)")
+          || major.includes("Minor Applied Mathematics & Statistics (NEW - 2021 & after)")) {
+            plan.majors[ind] = "Minor Applied Mathematics & Statistics";
+          } 
+        }
+        plan.majors =  [...new Set(plan.majors)];
+        // console.log("after: " + plan.majors + "");
+        await plan.save();
+        // console.log("done!\n");
+      }
+      if (plan !== null && plan.major_ids != null && plan.major_ids.length > 0) {
+        console.log("before: " + plan.major_ids);
+        for (let ind in plan.major_ids) {
+          let major = plan.major_ids[ind];
+          if (major.includes("B.A. Computer Science (NEW - 2021 & after)")) {
+            plan.major_ids[ind] = "B.A. Computer Science";
+          } else if (major.includes("B.S. Computer Science (OLD - Pre-2021)") 
+          || major.includes("B.S. Computer Science (NEW - 2021 & after)")) {
+            plan.major_ids[ind] = "B.S. Computer Science";
+          } else if (major.includes("Minor Computer Science (OLD - Pre-2021)")) {
+            plan.major_ids[ind] = "Minor Computer Science";
+          } else if (major.includes("Minor Computer Science (NEW - 2021 & after)")) {
+            plan.major_ids[ind] = "Minor Computer Science";
+          } else if (major.includes("Minor Applied Mathematics & Statistics (OLD - Pre-2021)")
+          || major.includes("Minor Applied Mathematics & Statistics (NEW - 2021 & after)")) {
+            plan.major_ids[ind] = "Minor Applied Mathematics & Statistics";
+          } 
+        }
+        plan.major_ids =  [...new Set(plan.major_ids)];
+        console.log("after: " + plan.major_ids + "");
+        await plan.save();
+        console.log("done!\n");
+      }
+    }
+  }
+  console.log("done")
+}
+
+replaceOldWithNew();
+
+
+async function checkResult() {
+  connect();
+
+  const users = await User.find({});
+  for (let user of users) {
+    for (let plan_id of user.plan_ids) {
+      let plan = await Plan.findById(plan_id).exec();
+      if (plan !== null && plan.majors != null && plan.majors.length > 0) {
+        console.log(plan.majors);
+      }
+    }
+  }
+}
+
+// checkResult();

--- a/data/replaceOldMajors.js
+++ b/data/replaceOldMajors.js
@@ -29,7 +29,6 @@ async function replaceOldWithNew() {
         }
         plan.majors =  [...new Set(plan.majors)];
         // console.log("after: " + plan.majors + "");
-        await plan.save();
         // console.log("done!\n");
       }
       if (plan !== null && plan.major_ids != null && plan.major_ids.length > 0) {
@@ -52,9 +51,9 @@ async function replaceOldWithNew() {
         }
         plan.major_ids =  [...new Set(plan.major_ids)];
         console.log("after: " + plan.major_ids + "");
-        await plan.save();
         console.log("done!\n");
       }
+      await plan.save();
     }
   }
   console.log("done")

--- a/data/updatePrereq.js
+++ b/data/updatePrereq.js
@@ -1,0 +1,342 @@
+import { connect } from "./db.js";
+import dotenv from "dotenv";
+import SISCourseV from '../model/SISCourseV.js';
+
+dotenv.config();
+
+async function updateIntroAlgo() {
+  connect();
+  const number = "EN.601.433";
+  const oldPrereq = [
+      {
+          "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231",
+          "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^)",
+          "IsNegative": "N"
+      },
+      {
+          "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+          "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+          "IsNegative": "Y"
+      }
+  ];
+
+  const newPrereq = [
+      {
+          "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+          "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+          "IsNegative": "N"
+      },
+      {
+          "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+          "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+          "IsNegative": "Y"
+      }
+  ];
+
+  let data = await SISCourseV.find({number});
+  let course = data[0];
+  for (let version of course.versions) {
+    version.preReq = newPrereq;
+  }
+  await course.save();
+  console.log("done!")
+}
+
+// updateIntroAlgo();
+
+async function checkUpdated() {
+  connect();
+  const number = "EN.601.433";
+  let data = await SISCourseV.find({number});
+  let course = data[0];
+
+  for (let version of course.versions) {
+    console.log(version.preReq);
+  }
+}
+
+checkUpdated();
+
+
+
+/** Intro Algo
+ * {
+    "data": {
+        "_id": "635df458662f1ebee559601f",
+        "terms": [
+            "Fall 2021",
+            "Spring 2023",
+            "Fall 2022",
+            "Spring 2022",
+            "Spring 2021",
+            "Fall 2020",
+            "Spring 2020",
+            "Fall 2019"
+        ],
+        "title": "Intro Algorithms",
+        "number": "EN.601.433",
+        "versions": [
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "BMED-BDS",
+                    "COGS-COMPCG",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "637042cbbfb975c236485bf9",
+                "areas": "EQ",
+                "term": "Fall 2021",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "COGS-COMPCG",
+                    "BMED-BDS",
+                    "ARCH-ARCH",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [
+                    {
+                        "RestrictionName": "Computer Science minors",
+                        "Description": ""
+                    },
+                    {
+                        "RestrictionName": "UGrad Computer Engineering majors",
+                        "Description": ""
+                    },
+                    {
+                        "RestrictionName": "UGrad Computer Science majors",
+                        "Description": ""
+                    }
+                ],
+                "_id": "635df5c8662f1ebee559ed3c",
+                "areas": "EQ",
+                "term": "Spring 2023",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "BMED-BDS",
+                    "COGS-COMPCG",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df59b662f1ebee559da76",
+                "areas": "EQ",
+                "term": "Fall 2022",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "COGS-COMPCG",
+                    "BMED-BDS",
+                    "ARCH-ARCH",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df571662f1ebee559c810",
+                "areas": "EQ",
+                "term": "Spring 2022",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "COGS-COMPCG",
+                    "BMED-BDS",
+                    "ARCH-ARCH",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df501662f1ebee5599dcf",
+                "areas": "EQ",
+                "term": "Spring 2021",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "BMED-BDS",
+                    "COGS-COMPCG",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df4c8662f1ebee559885b",
+                "areas": "EQ",
+                "term": "Fall 2020",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "COGS-COMPCG",
+                    "BMED-BDS",
+                    "ARCH-ARCH",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df489662f1ebee5596c56",
+                "areas": "EQ",
+                "term": "Spring 2020",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis.  [Analysis]"
+            },
+            {
+                "department": "EN Computer Science",
+                "tags": [
+                    "COGS-COMPCG",
+                    "BME-BDS",
+                    "BMED-BDS",
+                    "CSCI-THRY"
+                ],
+                "preReq": [
+                    {
+                        "Description": "EN.600.226/EN.601.226 AND (EN.553.171/EN.550.171 OR EN.553.172/EN.550.170 OR EN.600.271/EN.601.231 OR EN.601.230",
+                        "Expression": "EN.600.226[C]^AND^(^EN.553.171[C]^OR^EN.553.172[C]^OR^EN.600.271[C]^OR^EN.601.230[C]^)",
+                        "IsNegative": "N"
+                    },
+                    {
+                        "Description": "Students may receive credit for only one of EN.600.363, EN.600.463, EN.601.433, EN.601.633.",
+                        "Expression": "EN.600.363[C]^OR^EN.601.633[C]",
+                        "IsNegative": "Y"
+                    }
+                ],
+                "coReq": [],
+                "restrictions": [],
+                "_id": "635df458662f1ebee5596020",
+                "areas": "EQ",
+                "term": "Fall 2019",
+                "school": "Whiting School of Engineering",
+                "credits": 3,
+                "wi": false,
+                "level": "Upper Level Undergraduate",
+                "bio": "This course concentrates on the design of algorithms and the rigorous analysis of their efficiency. topics include the basic definitions of algorithmic complexity (worst case, average case); basic tools such as dynamic programming, sorting, searching, and selection; advanced data structures and their applications (such as union-find); graph algorithms and searching techniques such as minimum spanning trees, depth-first search, shortest paths, design of online algorithms and competitive analysis. [Analysis]"
+            }
+        ],
+        "__v": 9
+    }
+}
+ * 
+ */

--- a/tests/routes/course.spec.js
+++ b/tests/routes/course.spec.js
@@ -529,3 +529,63 @@ describe("Course Routes: PATCH /api/courses/dragged", () => {
     expect(res.status).toBe(500);
   });
 });
+
+
+
+describe("Course Routes: PATCH /api/courses/:course_id", () => {
+  it("Should return the new course added", async () => {
+    courses = await Courses.find({});
+    let oldCourse = courses[0];
+    const newCourse = SAMEPLE_COURSES[0];
+    // change taken status to true
+    const res = await request
+      .patch(`/api/courses/${course._id}`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
+      .send(newCourse);
+    
+    expect(res.status).toBe(200);
+    // check course deleted
+    oldCourse = await Courses.findById(oldCourse._id);
+    expect(oldCourse).toBeNull();
+    // check new course returned
+    const returnedCourse = res.body.data;
+    expect(returnedCourse.title).toBe(newCourse.title);
+    expect(returnedCourse.term).toBe(newCourse.term);
+    expect(returnedCourse.number).toBe(newCourse.number);
+    expect(returnedCourse.level).toBe(newCourse.level);
+    expect(returnedCourse.user_id).toBe(newCourse.user_id);
+    expect(returnedCourse.plan_id).toBe(newCourse.plan_id);
+  });
+
+  it("Should return status 403 for invalid user", async () => {
+    // course.taken is false by default
+    courses = await Courses.find({});
+    let course = courses[0];
+    // attempt to change taken status
+    const res = await request
+      .patch(`/api/courses/${course._id}`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_2}`)
+      .send(SAMEPLE_COURSES[0]);
+    expect(res.status).toBe(403);
+    // check old course still there
+    const thatCourse = await Courses.findById(course._id);
+    expect(thatCourse.title).toBe(course.title);
+  });
+
+  it("Should return status 500 for invalid id", async () => {
+    const res = await request
+      .patch(`/api/courses/changeStatus/${INVALID_ID}`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_1}`)
+      .send(SAMEPLE_COURSES[0]);
+    expect(res.status).toBe(500);
+  });
+
+  it("Should return status 400 for missing taken", async () => {
+    courses = await Courses.find({});
+    let course = courses[0];
+    const res = await request
+      .patch(`/api/courses/changeStatus/${course._id}`)
+      .set("Authorization", `Bearer ${TEST_TOKEN_1}`);
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Added PATCH /api/courses/:course_id which takes in a course id as param and a new course as req body for deleting the old course and adding the new course