### PR TITLE
Dev 184: Implement Filter by Recently Updated 

### DIFF
--- a/model/Plan.js
+++ b/model/Plan.js
@@ -5,13 +5,16 @@ const Schema = mongoose.Schema;
     This model refers to a user plan.
     A user can have multiple plans for different combination of majors.
 */
-const planSchema = new Schema({
-  name: { type: String, required: true },
-  majors: { type: [String] },
-  year_ids: [{ type: Schema.Types.ObjectId, ref: 'Year' }],
-  distribution_ids: [{ type: Schema.Types.ObjectId, ref: 'Distribution' }],
-  user_id: { type: String, required: true },
-  expireAt: { type: Date, expires: 60 * 60 * 24 },
-}, {timestamps: true});
+const planSchema = new Schema(
+  {
+    name: { type: String, required: true },
+    majors: { type: [String] },
+    year_ids: [{ type: Schema.Types.ObjectId, ref: 'Year' }],
+    distribution_ids: [{ type: Schema.Types.ObjectId, ref: 'Distribution' }],
+    user_id: { type: String, required: true },
+    expireAt: { type: Date, expires: 60 * 60 * 24 },
+  },
+  { timestamps: true },
+);
 
 export default mongoose.model('Plan', planSchema);

--- a/model/Plan.js
+++ b/model/Plan.js
@@ -12,6 +12,6 @@ const planSchema = new Schema({
   distribution_ids: [{ type: Schema.Types.ObjectId, ref: 'Distribution' }],
   user_id: { type: String, required: true },
   expireAt: { type: Date, expires: 60 * 60 * 24 },
-});
+}, {timestamps: true});
 
 export default mongoose.model('Plan', planSchema);

--- a/routes/course.js
+++ b/routes/course.js
@@ -139,7 +139,9 @@ router.post('/api/courses', auth, async (req, res) => {
     await Years.findByIdAndUpdate(retrievedCourse.year_id, {
       $push: { courses: retrievedCourse._id },
     }).exec();
-    await Plans.findByIdAndUpdate(course.plan_id, {updatedAt: Date().toLocaleString()});
+    await Plans.findByIdAndUpdate(course.plan_id, {
+      updatedAt: Date().toLocaleString(),
+    });
     returnData(retrievedCourse, res);
   } catch (err) {
     errorHandler(res, 500, err);
@@ -248,7 +250,9 @@ router.patch('/api/courses/dragged', auth, async (req, res) => {
         },
         { new: true, runValidators: true },
       ).exec();
-      await Plans.findByIdAndUpdate(retrievedCourses.plan_id, {updatedAt: Date().toLocaleString()});
+      await Plans.findByIdAndUpdate(retrievedCourses.plan_id, {
+        updatedAt: Date().toLocaleString(),
+      });
       returnData(updated, res);
     }
   } catch (err) {
@@ -283,7 +287,9 @@ router.delete('/api/courses/:course_id', auth, async (req, res) => {
       ).exec();
       await distributionCreditUpdate(distribution, course, false);
     }
-    await Plans.findByIdAndUpdate(course.plan_id, {updatedAt: Date().toLocaleString()});
+    await Plans.findByIdAndUpdate(course.plan_id, {
+      updatedAt: Date().toLocaleString(),
+    });
     returnData(course, res);
   } catch (err) {
     errorHandler(res, 500, err);

--- a/routes/course.js
+++ b/routes/course.js
@@ -139,6 +139,7 @@ router.post('/api/courses', auth, async (req, res) => {
     await Years.findByIdAndUpdate(retrievedCourse.year_id, {
       $push: { courses: retrievedCourse._id },
     }).exec();
+    await Plans.findByIdAndUpdate(course.plan_id, {updatedAt: Date().toLocaleString()});
     returnData(retrievedCourse, res);
   } catch (err) {
     errorHandler(res, 500, err);
@@ -247,6 +248,7 @@ router.patch('/api/courses/dragged', auth, async (req, res) => {
         },
         { new: true, runValidators: true },
       ).exec();
+      await Plans.findByIdAndUpdate(retrievedCourses.plan_id, {updatedAt: Date().toLocaleString()});
       returnData(updated, res);
     }
   } catch (err) {
@@ -281,6 +283,7 @@ router.delete('/api/courses/:course_id', auth, async (req, res) => {
       ).exec();
       await distributionCreditUpdate(distribution, course, false);
     }
+    await Plans.findByIdAndUpdate(course.plan_id, {updatedAt: Date().toLocaleString()});
     returnData(course, res);
   } catch (err) {
     errorHandler(res, 500, err);

--- a/routes/year.js
+++ b/routes/year.js
@@ -92,6 +92,7 @@ router.patch('/api/years/updateName', auth, async (req, res) => {
     year.name = name;
     await year.save();
     await Courses.updateMany({ year_id }, { year: name }).exec();
+    await Plans.findByIdAndUpdate(year.plan_id, {updatedAt: Date().toLocaleString()});
     returnData(year, res);
   } catch (err) {
     errorHandler(res, 400, err);
@@ -115,6 +116,7 @@ router.patch('/api/years/updateYear', auth, async (req, res) => {
     }
     retrievedYear.year = year;
     await retrievedYear.save();
+    await Plans.findByIdAndUpdate(retrievedYear.plan_id, {updatedAt: Date().toLocaleString()});
     returnData(retrievedYear, res);
   } catch (err) {
     errorHandler(res, 400, err);

--- a/routes/year.js
+++ b/routes/year.js
@@ -92,7 +92,9 @@ router.patch('/api/years/updateName', auth, async (req, res) => {
     year.name = name;
     await year.save();
     await Courses.updateMany({ year_id }, { year: name }).exec();
-    await Plans.findByIdAndUpdate(year.plan_id, {updatedAt: Date().toLocaleString()});
+    await Plans.findByIdAndUpdate(year.plan_id, {
+      updatedAt: Date().toLocaleString(),
+    });
     returnData(year, res);
   } catch (err) {
     errorHandler(res, 400, err);
@@ -116,7 +118,9 @@ router.patch('/api/years/updateYear', auth, async (req, res) => {
     }
     retrievedYear.year = year;
     await retrievedYear.save();
-    await Plans.findByIdAndUpdate(retrievedYear.plan_id, {updatedAt: Date().toLocaleString()});
+    await Plans.findByIdAndUpdate(retrievedYear.plan_id, {
+      updatedAt: Date().toLocaleString(),
+    });
     returnData(retrievedYear, res);
   } catch (err) {
     errorHandler(res, 400, err);


### PR DESCRIPTION
**Description:** 
On Reviewee dashboard, we want reviewees to be able to filter their reviewee's plans by recently updated plans.

**Implementation:** 
We want to start tracking when a plan is updated so we can filter plans by recently updated. Thus, I added a timestamps option to the plan constructor in mongoose so that mongoDB automatically adds and maintains "updatedAt" field to each plan to represent when it was last updated. Whenever a course is added or removed to a plan, or when a year is changed, an extra call is made to update the timestamp field as well.

**Testing:** 
Tested locally by updating plans and making sure reviewer dashboard updates appropriately. 